### PR TITLE
docs: remove unused Dependencies section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,23 @@ service. A brief description of the role goes here.
 ## Requirements
 
 Any prerequisites that may not be covered by Ansible itself or the role should
-be mentioned here. For instance, if the role uses the EC2 module, it may be a
-good idea to mention in this section that the `boto` package is required.
+be mentioned here.  This includes platform dependencies not managed by the
+role, hardware requirements, external collections, etc.  There should be a
+distinction between *control node* requirements (like collections) and
+*managed node* requirements (like special hardware, platform provisioning).
+
+
+### Collection requirements
+
+For instance, if the role depends on some collections and
+has a `meta/collection-requirements.yml` file for installing those
+dependencies, it should be mentioned here that the user should run
+
+```
+ansible-galaxy collection install -vv -r meta/collection-requirements.yml
+```
+
+on the *control node* before using the role.
 
 ## Role Variables
 
@@ -55,12 +70,6 @@ Example:
 
 Default `false` - if `true`, this means a reboot is needed to apply the changes
 made by the role
-
-## Dependencies
-
-A list of other roles hosted on Galaxy should go here, plus any details in
-regards to parameters that may need to be set for other roles, or variables
-that are used from other roles.
 
 ## Example Playbook
 


### PR DESCRIPTION
remove unused Dependencies section in README - it is confusing
to users who look at the README, see the `Dependencies` section
that says `None`, and think that there are no dependencies for
the role, when the actual dependencies are listed in the
`Requirements` section which is not even near the `Dependencies`
section.  So consistently use the `Requirements` section and
get rid of the `Dependencies` section.

In addition, for roles that use other system roles, they have a
`meta/collection-requirements.yml` file, and the README lists
these requirements and instructions.  However, these are only
required for github and Galaxy users, and not for users who
use the packaged roles, where it is confusing to see instructions
about installing requirements when none are needed.  We need to
make it easier to remove these sections when packaging.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
