### PR TITLE
ci: Use emulated TPM device on C9S

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -3,9 +3,7 @@ jobs:
   - job: tests
     trigger: pull_request
     targets:
-      centos-stream-9-x86_64:
-        distros: [RHEL-9.3.0-Nightly]
-    use_internal_tf: true
+      - centos-stream-9-x86_64
     skip_build: true
     tf_extra_params:
       environments:

--- a/packit-ci.fmf
+++ b/packit-ci.fmf
@@ -5,15 +5,8 @@ environment:
   DOCKERFILE_SYSTEMD: Dockerfile.systemd
 
 context:
-  swtpm: no
+  swtpm: yes
   agent: rust
-
-provision:
-  hardware:
-    tpm:
-      version: "2"
-    virtualization:
-      is-virtualized: true
 
 prepare:
   - how: shell
@@ -33,6 +26,7 @@ discover:
     url: https://github.com/RedHat-SP-Security/keylime-tests
     ref: rhel-9-main
     test:
+      - /setup/configure_swtpm_device
       - /setup/configure_kernel_ima_module/ima_policy_simple
   - name: Run_keylime_server_role_tests
     how: fmf


### PR DESCRIPTION
By using emulated TPM device we can drop dependency on internal Testing Farm and also speed up test system provisioning.