### PR TITLE
fix: add timeout for registrar service - use 30 second timeout for registrar and verifier

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,9 +36,16 @@
   ansible.builtin.wait_for:
     host: "{{ keylime_server_verifier_ip }}"
     port: "{{ keylime_server_verifier_port }}"
+    timeout: "{{ __keylime_service_timeout }}"
 
 - name: Ensure the registrar is enabled and started
   service:
     name: "{{ __keylime_server_registrar_service }}"
     state: started
     enabled: true
+
+- name: Make sure the registrar is up and running
+  ansible.builtin.wait_for:
+    host: "{{ keylime_server_registrar_ip }}"
+    port: "{{ keylime_server_registrar_port }}"
+    timeout: "{{ __keylime_service_timeout }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -40,3 +40,7 @@ __keylime_server_verifier_keys_certs_config: verifier-keys-certs.conf
 __keylime_server_registrar_ip_config: registrar-ip.conf
 __keylime_server_registrar_database_config: registrar-database.conf
 __keylime_server_registrar_keys_certs_config: registrar-keys-certs.conf
+
+# time, in seconds, to wait for the verifier and registrar
+# services to become available
+__keylime_service_timeout: 30


### PR DESCRIPTION
Cause: The registrar service can fail, but the Ansible service reports success.

Consequence: The user does not know that the registrar was mis-configured.

Fix: Check the registrar ip and port to ensure they become available.  Use a 30
second timeout for both the verifier and registrar as the default 300 seconds for
the `wait_for` module is too long.

Result: Users are notified in a timely manner if the services failed to start.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
