### PR TITLE
ci: Enable Packit CI for C10S

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -4,6 +4,7 @@ jobs:
     trigger: pull_request
     targets:
       - centos-stream-9-x86_64
+      - centos-stream-10-x86_64
     skip_build: true
     tf_extra_params:
       environments:

--- a/packit-ci.fmf
+++ b/packit-ci.fmf
@@ -3,16 +3,13 @@ summary: run ansible system roles test with IMA policy setup
 environment:
   DOCKERFILE_AGENT: Dockerfile.agent
   DOCKERFILE_SYSTEMD: Dockerfile.systemd
+  NETAVARK_FW: nftables
 
 context:
   swtpm: yes
   agent: rust
 
 prepare:
-  - how: shell
-    script:
-     - rpm -Uv https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm https://dl.fedoraproject.org/pub/epel/epel-next-release-latest-9.noarch.rpm || true
-    when: distro == rhel-9 or distro == centos-stream-9
   - how: shell
     script:
      - ln -s $(pwd) /var/tmp/keylime_server-role-sources
@@ -24,7 +21,7 @@ discover:
   - name: Configure_simple_IMA_policy
     how: fmf
     url: https://github.com/RedHat-SP-Security/keylime-tests
-    ref: rhel-9-main
+    ref: "@.tmt/dynamic_ref.fmf"
     test:
       - /setup/configure_swtpm_device
       - /setup/configure_kernel_ima_module/ima_policy_simple
@@ -37,9 +34,14 @@ discover:
       - "/functional/.*"
 
 adjust:
-  - when: distro != rhel-9 and distro == centos-stream-9
+  - when: distro != rhel-9 and distro == centos-stream-9 and distro != rhel-10 and distro == centos-stream-10
     enabled: false
-    because: keylime_server role is RHEL-9 only
+    because: keylime_server role is RHEL-9 and RHEL-10 only
+  - when: distro == rhel-9 or distro == centos-stream-9
+    prepare+:
+      - how: shell
+        script:
+          - rpm -Uv https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm https://dl.fedoraproject.org/pub/epel/epel-next-release-latest-9.noarch.rpm || true
 
 execute:
   how: tmt


### PR DESCRIPTION
Enhancement: Enable CI testin on C10 through Packit

Reason: Catch RHEL-10 related issues early.
