### PR TITLE
ci(packit): fix extra parameters for TF

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -6,6 +6,7 @@ jobs:
       - centos-stream-9-x86_64
       - centos-stream-10-x86_64
     skip_build: true
+    tmt_plan: packit-ci
     tf_extra_params:
       environments:
         - tmt:

--- a/packit-ci.fmf
+++ b/packit-ci.fmf
@@ -42,6 +42,7 @@ adjust:
     prepare+:
       - how: feature
         epel: enabled
+        order: 10
 
 execute:
   how: tmt

--- a/packit-ci.fmf
+++ b/packit-ci.fmf
@@ -37,11 +37,11 @@ adjust:
   - when: distro != rhel-9 and distro == centos-stream-9 and distro != rhel-10 and distro == centos-stream-10
     enabled: false
     because: keylime_server role is RHEL-9 and RHEL-10 only
-  - when: distro == rhel-9 or distro == centos-stream-9
+
+  - when: distro == rhel-9 or distro == centos-stream-9 or distro == rhel-10 or distro == centos-stream-10
     prepare+:
-      - how: shell
-        script:
-          - rpm -Uv https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm https://dl.fedoraproject.org/pub/epel/epel-next-release-latest-9.noarch.rpm || true
+      - how: feature
+        epel: enabled
 
 execute:
   how: tmt

--- a/plans/test_playbooks_parallel.fmf
+++ b/plans/test_playbooks_parallel.fmf
@@ -29,15 +29,6 @@ prepare:
       if grep -q 'CentOS Linux release 7.9' /etc/redhat-release; then
         sed -i '/^mirror/d;s/#\?\(baseurl=http:\/\/\)mirror/\1vault/' /etc/yum.repos.d/*.repo
       fi
-  # Replace with feature: epel: enabled once https://github.com/teemtee/tmt/pull/3128 is merged
-  - name: Enable epel to install beakerlib
-    script: |
-      # CS 10 and Fedora doesn't require epel
-      if grep -q -e 'CentOS Stream release 10' -e 'Fedora release' /etc/redhat-release; then
-        exit 0
-      fi
-      yum install epel-release yum-utils -y
-      yum-config-manager --enable epel epel-debuginfo epel-source
 discover:
   - name: Prepare managed node
     how: fmf
@@ -60,5 +51,12 @@ discover:
   #   filter: tag:reserve_system
   #   url: https://github.com/linux-system-roles/tft-tests
   #   ref: main
+
+adjust:
+  - when: distro == rhel-9 or distro == centos-stream-9 or distro == rhel-10 or distro == centos-stream-10
+    prepare+:
+      - how: feature
+        epel: enabled
+
 execute:
     how: tmt

--- a/plans/test_playbooks_parallel.fmf
+++ b/plans/test_playbooks_parallel.fmf
@@ -57,6 +57,7 @@ adjust:
     prepare+:
       - how: feature
         epel: enabled
+        order: 10
 
 execute:
     how: tmt


### PR DESCRIPTION
`context` is nested under the `tmt` key. Noticed in Packit monitoring where it trips on failed requests to the Testing Farm.

Enhancement:

Fixed the `tf_extra_params` in the Packit config.

Reason:

Failing CI, also spams our Sentry backlog.

Result:

Green CI, doesn't spam our Sentry.

Issue Tracker Tickets (Jira or BZ if any):

- PCKT-002-PACKIT-SERVICE-896 (is internal to Packit, I guess)
- packit/agile#804