### PR TITLE
refactor: support ansible 2.19

### DIFF
--- a/tests/tasks/check_header.yml
+++ b/tests/tasks/check_header.yml
@@ -9,8 +9,8 @@
 - name: Check for presence of ansible managed header, fingerprint
   assert:
     that:
-      - ansible_managed in content
+      - __ansible_managed in content
       - __fingerprint in content
   vars:
     content: "{{ (__file_content | d(__content)).content | b64decode }}"
-    ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"
+    __ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"


### PR DESCRIPTION
Do not use ansible_managed directly

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Refactor tests to avoid direct use of ansible_managed by renaming it to __ansible_managed for compatibility with Ansible 2.19

Enhancements:
- Support Ansible 2.19 by replacing direct ansible_managed references with __ansible_managed

Tests:
- Update check_header.yml assertions to verify __ansible_managed instead of ansible_managed