### PR TITLE
docs(changelog): version 1.1.8 [citest skip]

### DIFF
--- a/.README.html
+++ b/.README.html
@@ -58,8 +58,9 @@ SOFTWARE.
   </style>
   <style type="text/css">code{white-space: pre;}</style>
   <style type="text/css">
+html { -webkit-text-size-adjust: 100%; }
 pre > code.sourceCode { white-space: pre; position: relative; }
-pre > code.sourceCode > span { line-height: 1.25; }
+pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
 pre > code.sourceCode > span:empty { height: 1.2em; }
 .sourceCode { overflow: visible; }
 code.sourceCode > span { color: inherit; text-decoration: inherit; }
@@ -70,7 +71,7 @@ div.sourceCode { overflow: auto; }
 }
 @media print {
 pre > code.sourceCode { white-space: pre-wrap; }
-pre > code.sourceCode > span { display: inline-block; text-indent: -5em; padding-left: 5em; }
+pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
 }
 pre.numberSource code
   { counter-reset: source-line 0; }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
 Changelog
 =========
 
+[1.1.8] - 2025-07-02
+--------------------
+
+### Other Changes
+
+- ci: ansible-plugin-scan is disabled for now (#63)
+- ci: bump ansible-lint to v25; provide collection requirements for ansible-lint (#66)
+- ci: Check spelling with codespell (#67)
+- ci: Add test plan that runs CI tests and customize it for each role (#68)
+- ci: In test plans, prefix all relate variables with SR_ (#69)
+- ci: Fix bug with ARTIFACTS_URL after prefixing with SR_ (#70)
+- ci: several changes related to new qemu test, ansible-lint, python versions, ubuntu versions (#71)
+- ci: use tox-lsr 3.6.0; improve qemu test logging (#72)
+- ci: skip storage scsi, nvme tests in github qemu ci (#73)
+- ci: Bump sclorg/testing-farm-as-github-action from 3 to 4 (#74)
+- ci: bump tox-lsr to 3.8.0; rename qemu/kvm tests (#76)
+- ci: Add Fedora 42; use tox-lsr 3.9.0; use lsr-report-errors for qemu tests (#77)
+- ci: Add support for bootc end-to-end validation tests (#78)
+- ci: Use ansible 2.19 for fedora 42 testing; support python 3.13 (#79)
+- refactor: support ansible 2.19 (#80)
+
 [1.1.7] - 2025-01-09
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.1.8

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Update project to version 1.1.8 by adding changelog entries for a range of CI improvements, Ansible 2.19 support, and CSS tweaks in the README HTML.

CI:
- Disable ansible-plugin-scan; bump ansible-lint to v25 with collection requirements and upgrade tox-lsr through v3.9.0
- Integrate codespell for spelling checks and prefix CI variables with SR_ (fixing ARTIFACTS_URL)
- Improve QEMU test plans and logging, skip storage scsi/nvme tests, and bump testing-farm-as-github-action to v4
- Add Fedora 42 and Python 3.13 testing and support bootc end-to-end validation tests

Documentation:
- Update README.html CSS to enable mobile text scaling and fix code block span styling