### PR TITLE
feat: add openSUSE Leap 15.6 to integration test matrix

### DIFF
--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -41,6 +41,7 @@ jobs:
           - { image: "fedora-42", env: "container-ansible-core-2.17" }
           - { image: "fedora-41-bootc", env: "container-ansible-core-2.17" }
           - { image: "fedora-42-bootc", env: "container-ansible-core-2.17" }
+          - { image: "leap-15.6", env: "qemu-ansible-core-2.18" }
 
     env:
       TOX_ARGS: "--skip-tags tests::infiniband,tests::nvme,tests::scsi"
@@ -62,6 +63,7 @@ jobs:
           case "$image" in
           centos-*) platform=el; platform_version=el"${image#centos-}" ;;
           fedora-*) platform=fedora; platform_version="${image/-/}" ;;
+          leap-*) platform=leap; platform_version="${image}" ;;
           esac
           supported=
           if yq -e '.galaxy_info.galaxy_tags[] | select(. == "'${platform_version}'" or . == "'${platform}'")' meta/main.yml; then

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -9,5 +9,5 @@ jobs:
     tf_extra_params:
       environments:
         - tmt:
-          context:
-            target_PR_branch: "main"
+            context:
+              target_PR_branch: "main"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Ansible role for configuring and deploying the server components for Keylime Rem
 
 * RHEL-9.1+, CentOS Stream 9.1+
 * Fedora 36+
+* SLES 15-SP6+, openSUSE Leap 15.6+
 
 ## Requirements
 

--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -2,3 +2,4 @@
 ---
 collections:
   - ansible.posix
+  - community.general

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -20,4 +20,6 @@ galaxy_info:
     - fedora
     - keylime
     - redhat
+    - leap
+    - sles
 dependencies: []


### PR DESCRIPTION
Enhancement: add openSUSE Leap 15.6 to integration test matrix

Reason: add leap to integration test

Result: Leap 15.6 test runs in CI

Issue Tracker Tickets (Jira or BZ if any): na

## Summary by Sourcery

Add openSUSE Leap 15.6 to the integration test matrix and support metadata, documentation, and requirements accordingly

Enhancements:
- Include openSUSE Leap 15.6 in the QEMU-KVM integration test matrix and update the CI platform detection logic
- Add 'leap' and 'sles' tags to galaxy_info in meta/main.yml
- Document SLES 15-SP6+ and openSUSE Leap 15.6 as supported platforms in README.md
- Add community.general to the collection requirements