### PR TITLE
ci: use tox-lsr 3.12.0 for osbuild_config.yml feature

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.11.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.12.0"
 
       - name: Convert role to collection format
         id: collection

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.11.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.12.0"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.11.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.12.0"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -107,7 +107,7 @@ jobs:
           python3 -m pip install --upgrade pip
           sudo apt update
           sudo apt install -y --no-install-recommends git ansible-core genisoimage qemu-system-x86
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.11.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.12.0"
 
       # HACK: Drop this when moving this workflow to 26.04 LTS
       - name: Update podman to 5.x for compatibility with bootc-image-builder's podman 5


### PR DESCRIPTION
Use tox-lsr 3.12.0 for the new osbuild_config.yml feature for bootc and users
https://github.com/linux-system-roles/tox-lsr/pull/211

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Upgrade tox-lsr to version 3.12.0 across CI workflows to support the new osbuild_config.yml feature

CI:
- Bump tox-lsr dependency to v3.12.0 in ansible-lint, ansible-managed-var-comment, and ansible-test workflows
- Update tox-lsr version to v3.12.0 in the qemu-kvm-integration-tests workflow