### PR TITLE
ci: use exact match for systemroller instead of contains [citest_skip]

### DIFF
--- a/.github/workflows/tft.yml
+++ b/.github/workflows/tft.yml
@@ -22,7 +22,7 @@ jobs:
       github.event.issue.pull_request
       && contains(github.event.comment.body, '[citest]')
       && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
-      || contains('systemroller', github.event.comment.user.login))
+      || github.event.comment.user.login == 'systemroller')
     runs-on: ubuntu-latest
     outputs:
       supported_platforms: ${{ steps.supported_platforms.outputs.supported_platforms }}


### PR DESCRIPTION
This guards against the possibility of a user with 'systemroller' as part
of the username.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
